### PR TITLE
Rename the helm chart release_name variable for Kapitan to name

### DIFF
--- a/class/minio.yml
+++ b/class/minio.yml
@@ -26,5 +26,5 @@ parameters:
           - minio/helmcharts/minio
         helm_values: ${minio:helmValues}
         helm_params:
-          release_name: minio-${_instance}
+          name: minio-${_instance}
           namespace: "${minio:namespace}"


### PR DESCRIPTION
Kapitan has changed the helm chart naming and release_name is
now deprecated.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
