### PR TITLE
Fix tenant name reclass references

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,8 +7,8 @@ parameters:
       minio: 8.0.0
     adminCredentials:
       secretName: admin-credentials-${_instance}
-      accessKey: ?{vaultkv:${customer:name}/${cluster:name}/minio/${_instance}-accesskey}
-      secretKey: ?{vaultkv:${customer:name}/${cluster:name}/minio/${_instance}-secretkey}
+      accessKey: ?{vaultkv:${cluster:tenant}/${cluster:name}/minio/${_instance}-accesskey}
+      secretKey: ?{vaultkv:${cluster:tenant}/${cluster:name}/minio/${_instance}-secretkey}
     helmValues:
       existingSecret: ${minio:adminCredentials:secretName}
       azuregateway:


### PR DESCRIPTION
We've deprecated `customer.name` a while ago.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
